### PR TITLE
Add method for creating a one line histogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,25 @@ pip3 install asciietch
 ```
 Then import asciietch and begin using it.
 ## Examples
-### Graphing 0-4 values
+### Graphing 0-4 values as a line graph
 ```python
 >>> from asciietch.graph import Grapher
 >>> g = Grapher()
 >>> values = [0, 1, 2, 3, 4]
 >>> print(g.asciigraph(values))
-```
-```
     -
    /
   /
  /
 /
+```
+### Graphing 0-4 values as a histogram
+```python
+>>> from asciietch.graph import Grapher
+>>> g = Grapher()
+>>> values = [0, 1, 2, 3, 4]
+>>> print(g.asciihist(values))
+▁▃▅▆█
 ```
 ### Graphing more values
 ```python
@@ -28,13 +34,13 @@ Then import asciietch and begin using it.
 >>> g = Grapher()
 >>> values = [0, 1, 2, 3, 4, 4, 3, 2, 1, 2, 2, 2]
 >>> print(g.asciigraph(values))
-```
-```
     --
    /  \
   /    \ ---
  /      -
 /
+>>> print(g.asciihist(values))
+▁▃▅▆██▆▅▃▅▅▅
 ```
 ### Graphing a large set of values and adding labels
 ```python

--- a/asciietch/graph.py
+++ b/asciietch/graph.py
@@ -49,10 +49,11 @@ class Grapher(object):
         if scale_old_from_zero:
             y_min_value = 0
         y_max_value = max(values)
-        OldRange = (y_max_value - y_min_value) or 1  # Prevents division by zero if all values are the same
-        NewRange = (new_max - new_min)  # max_height is new_max
+        # Prevents division by zero if all values are the same
+        old_range = (y_max_value - y_min_value) or 1
+        new_range = (new_max - new_min)  # max_height is new_max
         for old_value in values:
-            new_value = (((old_value - y_min_value) * NewRange) / OldRange) + new_min
+            new_value = (((old_value - y_min_value) * new_range) / old_range) + new_min
             scaled_values.append(new_value)
         return scaled_values
 

--- a/asciietch/graph.py
+++ b/asciietch/graph.py
@@ -137,13 +137,8 @@ class Grapher(object):
 
         # If this is a dict of timestamp -> value, sort the data, store the start/end time, and convert values to a list of values
         if isinstance(values, dict):
-            time_series_sorted = sorted(list(values.items()), key=lambda x: x[0])  # Sort timestamp/value dict by the timestamps
-
-            start_timestamp = time_series_sorted[0][0]
-            end_timestamp = time_series_sorted[-1][0]
-
-            start_ctime = datetime.fromtimestamp(float(start_timestamp)).ctime()
-            end_ctime = datetime.fromtimestamp(float(end_timestamp)).ctime()
+            time_series_sorted = self._sort_timeseries_values(values)
+            start_ctime, end_ctime = self._get_start_and_end_ctimes(time_series_sorted)
             values = self._scale_x_values_timestamps(values=time_series_sorted, max_width=max_width)
         values = [value for value in values if value is not None]
 
@@ -178,6 +173,27 @@ class Grapher(object):
         else:
             result = graph_string
         return result
+
+    def _get_start_and_end_ctimes(self, time_series_sorted):
+        """Get the start and end times of a sorted time series data as ctime. """
+        start_timestamp = time_series_sorted[0][0]
+        end_timestamp = time_series_sorted[-1][0]
+
+        start_ctime = datetime.fromtimestamp(float(start_timestamp)).ctime()
+        end_ctime = datetime.fromtimestamp(float(end_timestamp)).ctime()
+
+        return start_ctime, end_ctime
+
+    def _sort_timeseries_values(self, values_dict):
+        """Sort the data by time if data is given as a time->value dictionary."""
+        values_timestamps = {
+            datetime.strptime(value, '%d-%m-%Y').timestamp(): values_dict[value]
+            for value in values_dict
+        }
+        # Sort timestamp/value dict by the timestamps
+        time_series_sorted = sorted(list(values_timestamps.items()),
+                                    key=lambda x: x[0])
+        return time_series_sorted
 
     def _surround_with_label(self,
                              graph_string,

--- a/asciietch/graph.py
+++ b/asciietch/graph.py
@@ -6,6 +6,7 @@ import statistics
 from datetime import datetime
 
 BORDER_FILL_CHARACTER = '*'
+DEFAULT_MAX_WIDTH = 180
 
 
 class Grapher(object):
@@ -132,8 +133,7 @@ class Grapher(object):
         start_ctime = None
         end_ctime = None
 
-        if not max_width:
-            max_width = 180
+        max_width = max_width or DEFAULT_MAX_WIDTH
 
         # If this is a dict of timestamp -> value, sort the data, store the start/end time, and convert values to a list of values
         if isinstance(values, dict):
@@ -230,8 +230,7 @@ class Grapher(object):
         start_ctime = None
         end_ctime = None
 
-        if not max_width:
-            max_width = 180
+        max_width = max_width or DEFAULT_MAX_WIDTH
 
         max_height = len(allowed_bars_in_order) - 1
 

--- a/asciietch/graph.py
+++ b/asciietch/graph.py
@@ -240,12 +240,11 @@ class Grapher(object):
             time_series_sorted = self._sort_timeseries_values(values)
             start_ctime, end_ctime = self._get_start_and_end_ctimes(time_series_sorted)
             values = self._scale_x_values_timestamps(values=time_series_sorted, max_width=max_width)
+
         values = [value for value in values if value is not None]
-        # print(values)
 
         # Do value adjustments
         adjusted_values = self._scale_x_values(values=values, max_width=max_width)
-        # print(adjusted_values)
 
         # Getting upper/lower after scaling x values so we don't label a spike we can't see
         upper_value = max(adjusted_values)
@@ -254,7 +253,6 @@ class Grapher(object):
         adjusted_values = self._scale_y_values(values=adjusted_values, new_min=0,
                                                new_max=max_height, scale_old_from_zero=False)
         adjusted_values = self._round_floats_to_ints(values=adjusted_values)
-        # print(f'After scaling y: {adjusted_values}')
 
         # Obtain Ascii Histogram String
         field = [allowed_bars_in_order[val] for val in adjusted_values]

--- a/asciietch/graph.py
+++ b/asciietch/graph.py
@@ -124,7 +124,7 @@ class Grapher(object):
         graph_string = '\n'.join(row_strings)
         return graph_string
 
-    def asciigraph(self, values=None, max_height=None, max_width=None, label=False):
+    def asciigraph(self, values, max_height=None, max_width=None, label=False):
         '''
         Accepts a list of y values and returns an ascii graph
         Optionally values can also be a dictionary with a key of timestamp, and a value of value. InGraphs returns data in this format for example.

--- a/asciietch/graph.py
+++ b/asciietch/graph.py
@@ -5,6 +5,8 @@ import statistics
 import random
 from datetime import datetime
 
+BORDER_FILL_CHARACTER = '*'
+
 
 class Grapher(object):
 
@@ -127,8 +129,6 @@ class Grapher(object):
         Accepts a list of y values and returns an ascii graph
         Optionally values can also be a dictionary with a key of timestamp, and a value of value. InGraphs returns data in this format for example.
         '''
-        result = ''
-        border_fill_char = '*'
         start_ctime = None
         end_ctime = None
 
@@ -162,23 +162,49 @@ class Grapher(object):
         graph_string = self._draw_ascii_graph(field=field)
 
         # Label the graph
-        if label:
-            top_label = 'Upper value: {upper_value:.2f} '.format(upper_value=upper_value).ljust(max_width, border_fill_char)
-            result += top_label + '\n'
-        result += '{graph_string}\n'.format(graph_string=graph_string)
+
         if label:
             stdev = statistics.stdev(values)
             mean = statistics.mean(values)
 
-            lower = f'Lower value: {lower_value:.2f} '
-            stats = f' Mean: {mean:.2f} *** Std Dev: {stdev:.2f} ******'
-            fill_length = max_width - len(lower) - len(stats)
-            stat_label = f'{lower}{"*" * fill_length}{stats}\n'
-            result += stat_label
+            result = self._surround_with_label(graph_string,
+                                               max_width,
+                                               upper_value,
+                                               lower_value,
+                                               stdev,
+                                               mean,
+                                               start_ctime,
+                                               end_ctime)
+        else:
+            result = graph_string
+        return result
 
-            if start_ctime and end_ctime:
-                fill_length = max_width - len(start_ctime) - len(end_ctime)
-                result += f'{start_ctime}{" " * fill_length}{end_ctime}\n'
+    def _surround_with_label(self,
+                             graph_string,
+                             max_width,
+                             max_val,
+                             min_val,
+                             stdev,
+                             mean,
+                             start_ctime=None,
+                             end_ctime=None):
+        """Surround the graph string with labels.
+
+        It adds a top label with the max value of the data.
+        And a bottom label with min value and data statistics.
+        """
+        top_label = f'Upper value: {max_val:.2f} '.ljust(max_width, BORDER_FILL_CHARACTER)
+        lower = f'Lower value: {min_val:.2f} '
+        stats = f' Mean: {mean:.2f} *** Std Dev: {stdev:.2f} ******'
+        fill_length = max_width - len(lower) - len(stats)
+        stat_label = f'{lower}{"*" * fill_length}{stats}'
+
+        result = top_label + '\n' + graph_string + '\n' + stat_label
+
+        if start_ctime and end_ctime:
+            fill_length = max_width - len(start_ctime) - len(end_ctime)
+            time_label = f'{start_ctime}{" " * fill_length}{end_ctime}\n'
+            result += time_label
 
         return result
 

--- a/asciietch/graph.py
+++ b/asciietch/graph.py
@@ -215,8 +215,8 @@ class Grapher(object):
 
         if start_ctime and end_ctime:
             fill_length = max_width - len(start_ctime) - len(end_ctime)
-            time_label = f'{start_ctime}{" " * fill_length}{end_ctime}\n'
-            result += time_label
+            time_label = f'{start_ctime} {" " * fill_length}{end_ctime}\n'
+            result += '\n' + time_label
 
         return result
 

--- a/asciietch/graph.py
+++ b/asciietch/graph.py
@@ -185,15 +185,11 @@ class Grapher(object):
         return start_ctime, end_ctime
 
     def _sort_timeseries_values(self, values_dict):
-        """Sort the data by time if data is given as a time->value dictionary."""
-        values_timestamps = {
-            datetime.strptime(value, '%d-%m-%Y').timestamp(): values_dict[value]
-            for value in values_dict
-        }
-        # Sort timestamp/value dict by the timestamps
-        time_series_sorted = sorted(list(values_timestamps.items()),
-                                    key=lambda x: x[0])
-        return time_series_sorted
+        """Sort the data by time if data is given as a time->value dictionary.
+
+        Sort the timeseries data and return as list of tuples.
+        """
+        return sorted(values_dict.items(), key=lambda x: x[0])
 
     def _surround_with_label(self,
                              graph_string,

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -161,3 +161,22 @@ def test_timestamp_as_string_with_none_values():
     log.debug(f"result: {result}")
     assert len(result) == 1
     assert result[0] > 4.5 and result[0] < 5
+
+def test_surround_with_label_adds_two_extra_lines():
+    """Surround with label adds a line above and below the graph string."""
+    graph_string = \
+        '''
+          /
+         /
+        /
+        '''
+    g = Grapher()
+    label_surrounded_string = g._surround_with_label(
+        graph_string,
+        100,
+        4,
+        0,
+        1.29,
+        2.5
+    )
+    assert len(label_surrounded_string.splitlines()) == len(graph_string.splitlines()) + 2

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -28,7 +28,6 @@ def test_ascii_scale_values_down():
 
 
 def test_ascii_scale_values_equal():
-
     g = Grapher()
 
     # Transpose 20-40 to 0-20
@@ -40,7 +39,6 @@ def test_ascii_scale_values_equal():
 
 
 def test_ascii_scale_values_up():
-
     g = Grapher()
 
     # Transpose 20-40 to 0-20
@@ -65,6 +63,22 @@ def test_ascii_compress_values():
     # Test that we can fit the max_width exactly
     values = list(range(1, 12))
     assert g._scale_x_values(values=values, max_width=3) == [2, 5.5, 9.5]
+
+
+def test_sort_timeseries_values():
+    g = Grapher()
+    time_data = {
+        '1578162600': 5,
+        '1577903400': 2,
+        '1577817000': 1,
+    }
+    sorted_values = g._sort_timeseries_values(time_data)
+    expected_values = [
+        ('1577817000', 1),
+        ('1577903400', 2),
+        ('1578162600', 5),
+    ]
+    assert expected_values == sorted_values
 
 
 def test_ascii_round_floats_to_ints():

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -162,6 +162,45 @@ def test_timestamp_as_string_with_none_values():
     assert len(result) == 1
     assert result[0] > 4.5 and result[0] < 5
 
+
+class TestAsciiHist:
+    g = Grapher()
+    values = [1, 2, 3, 4]
+
+    def test_hist_with_no_axis_scaling_has_same_length_as_input_values(self):
+        ascii_histogram = self.g.asciihist(self.values)
+        assert len(ascii_histogram) == len(self.values)
+
+    def test_hist_prints_one_line(self):
+        ascii_histogram = self.g.asciihist(self.values)
+        assert len(ascii_histogram.splitlines()) == 1
+
+    def test_hist_with_label_prints_three_lines(self):
+        ascii_histogram = self.g.asciihist(self.values, label=True)
+        assert len(ascii_histogram.splitlines()) == 3
+
+    def test_hist_with_label_prints_max_and_min_values(self):
+        ascii_histogram = self.g.asciihist(self.values, label=True)
+        top_line, graph_line, bottom_line = ascii_histogram.splitlines()
+        max_val = max(self.values)
+        min_val = min(self.values)
+
+        assert f'Upper value: {max_val}' in top_line
+        assert f'Lower value: {min_val}' in bottom_line
+
+    def test_hist_with_label_prints_data_statistics(self):
+        ascii_histogram = self.g.asciihist(self.values, label=True)
+        top_line, graph_line, bottom_line = ascii_histogram.splitlines()
+
+        assert 'Mean:' in bottom_line
+        assert 'Std Dev:' in bottom_line
+
+    def test_hist_with_max_width_less_than_number_of_values(self):
+        """Graph should have a max width of max_width."""
+        ascii_histogram = self.g.asciihist(self.values, max_width=3)
+        assert len(ascii_histogram) == 3
+
+
 def test_surround_with_label_adds_two_extra_lines():
     """Surround with label adds a line above and below the graph string."""
     graph_string = \

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -215,8 +215,7 @@ class TestAsciiHist:
         assert len(ascii_histogram) == 3
 
 
-def test_surround_with_label_adds_two_extra_lines():
-    """Surround with label adds a line above and below the graph string."""
+class TestSurroundWithLabel:
     graph_string = \
         '''
           /
@@ -224,12 +223,29 @@ def test_surround_with_label_adds_two_extra_lines():
         /
         '''
     g = Grapher()
-    label_surrounded_string = g._surround_with_label(
-        graph_string,
-        100,
-        4,
-        0,
-        1.29,
-        2.5
-    )
-    assert len(label_surrounded_string.splitlines()) == len(graph_string.splitlines()) + 2
+
+    def test_surround_adds_two_extra_lines(self):
+        """Surround with label adds a line above and below the graph string."""
+        label_surrounded_string = self.g._surround_with_label(
+            self.graph_string,
+            100,
+            4,
+            0,
+            1.29,
+            2.5
+        )
+        assert len(label_surrounded_string.splitlines()) == len(self.graph_string.splitlines()) + 2
+
+    def test_surround_adds_three_lines_with_timestamps(self):
+        """Surround with label will add another line for timestamps at the end."""
+        label_surrounded_string = self.g._surround_with_label(
+            self.graph_string,
+            100,
+            4,
+            0,
+            1.29,
+            2.5,
+            start_ctime='Wed Jan  1 00:00:00 2020',
+            end_ctime='Sun Jan  5 00:00:00 2020',
+        )
+        assert len(label_surrounded_string.splitlines()) == len(self.graph_string.splitlines()) + 3


### PR DESCRIPTION
The following are the changes made:
- Added the `asciihist` method through which we can make single line histograms (Mentioned in #3)

The common functionality between `asciihist` and the `asciigraph` is extracted into common methods. 
The following three methods were created for the common code.
- _get_start_and_end_ctimes 
- _sort_timeseries_values
- _surround_with_label

Added test cases for the `asciihist` method. 

Sample usage of `asciihist`:
```
>>> from asciietch.graph import Grapher
>>> g = Grapher()
>>> values = [1,2,3,4,5]
>>> g.asciihist(values)
'▁▃▅▆█'
>>> values = [0, 2, 4, 6, 8, 6, 4, 2, 0]
>>> g.asciihist(values)
'▁▃▅▆█▆▅▃▁'
```